### PR TITLE
Run tests on PHP 8 and PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.gitignore export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           php-version: ${{ matrix.php }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
@@ -36,6 +39,5 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
-      - run: hhvm $(which composer) require phpunit/phpunit:^5 --dev --no-interaction # requires legacy phpunit
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ $ composer require clue/ndjson-react:^1.1
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     },
     "require-dev": {
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="NDJSON test suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="NDJSON test suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/DecoderTest.php
+++ b/tests/DecoderTest.php
@@ -10,7 +10,10 @@ class DecoderTest extends TestCase
     private $input;
     private $decoder;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpDecoder()
     {
         $this->input = new ThroughStream();
         $this->decoder = new Decoder($this->input);
@@ -76,7 +79,7 @@ class DecoderTest extends TestCase
         $this->input->emit('data', array("invalid\n"));
 
         $this->assertInstanceOf('RuntimeException', $error);
-        $this->assertContains('Syntax error', $error->getMessage());
+        $this->assertContainsString('Syntax error', $error->getMessage());
         $this->assertEquals(JSON_ERROR_SYNTAX, $error->getCode());
     }
 

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -10,7 +10,10 @@ class EncoderTest extends TestCase
     private $output;
     private $encoder;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpEncoder()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
@@ -19,15 +22,13 @@ class EncoderTest extends TestCase
         $this->encoder = new Encoder($this->output);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testPrettyPrintDoesNotMakeSenseForNDJson()
     {
         if (!defined('JSON_PRETTY_PRINT')) {
             $this->markTestSkipped('Const JSON_PRETTY_PRINT only available in PHP 5.4+');
         }
 
+        $this->setExpectedException('InvalidArgumentException');
         $this->encoder = new Encoder($this->output, JSON_PRETTY_PRINT);
     }
 
@@ -77,11 +78,11 @@ class EncoderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $error);
         if (PHP_VERSION_ID >= 50500) {
             // PHP 5.5+ reports error with proper code
-            $this->assertContains('Inf and NaN cannot be JSON encoded', $error->getMessage());
+            $this->assertContainsString('Inf and NaN cannot be JSON encoded', $error->getMessage());
             $this->assertEquals(JSON_ERROR_INF_OR_NAN, $error->getCode());
         } else {
             // PHP < 5.5 reports error message without code
-            $this->assertContains('double INF does not conform to the JSON spec', $error->getMessage());
+            $this->assertContainsString('double INF does not conform to the JSON spec', $error->getMessage());
             $this->assertEquals(0, $error->getCode());
         }
     }
@@ -109,7 +110,7 @@ class EncoderTest extends TestCase
         $this->assertInstanceOf('RuntimeException', $error);
         if (PHP_VERSION_ID >= 50500) {
             // PHP 5.5+ reports error with proper code
-            $this->assertContains('Malformed UTF-8 characters, possibly incorrectly encoded', $error->getMessage());
+            $this->assertContainsString('Malformed UTF-8 characters, possibly incorrectly encoded', $error->getMessage());
             $this->assertEquals(JSON_ERROR_UTF8, $error->getCode());
         } elseif (PHP_VERSION_ID >= 50303) {
             // PHP 5.3.3+ reports error with proper code (const JSON_ERROR_UTF8 added in PHP 5.3.3)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,4 +41,32 @@ class TestCase extends BaseTestCase
     {
         return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
     }
+
+    public function assertContainsString($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            // PHPUnit 7.5+
+            $this->assertStringContainsString($needle, $haystack);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.5
+            $this->assertContains($needle, $haystack);
+        }
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #22.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0 php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

.........................................                         41 / 41 (100%)

Time: 00:00.020, Memory: 6.00 MB

OK (41 tests, 89 assertions)
```