### PR TITLE
Simplify examples by updating to new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ as parsed values instead of just chunks of strings:
 ```
 
 ```php
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 
 $stream = new Decoder($stdin);
 
@@ -234,7 +234,7 @@ and accepts its data through the same interface, but handles any data as complet
 JSON elements instead of just chunks of strings:
 
 ```php
-$stdout = new WritableResourceStream(STDOUT, $loop);
+$stdout = new WritableResourceStream(STDOUT);
 
 $stream = new Encoder($stdout);
 

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
             "email": "christian@clue.engineering"
         }
     ],
+    "require": {
+        "php": ">=5.3",
+        "react/stream": "^1.2"
+    },
+    "require-dev": {
+        "react/event-loop": "^1.2",
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+    },
     "autoload": {
         "psr-4": { "Clue\\React\\NDJson\\": "src/" }
     },
     "autoload-dev": {
         "psr-4": { "Clue\\Tests\\React\\NDJson\\": "tests/" }
-    },
-    "require": {
-        "php": ">=5.3",
-        "react/stream": "^1.0 || ^0.7 || ^0.6"
-    },
-    "require-dev": {
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/examples/validate.php
+++ b/examples/validate.php
@@ -2,20 +2,18 @@
 
 // $ php examples/validate.php < examples/users.ndjson
 
-use React\EventLoop\Factory;
-use React\Stream\ReadableResourceStream;
-use React\Stream\WritableResourceStream;
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
+use React\EventLoop\Loop;
+use React\Stream\ReadableResourceStream;
+use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
 $exit = 0;
-$in = new ReadableResourceStream(STDIN, $loop);
-$out = new WritableResourceStream(STDOUT, $loop);
-$info = new WritableResourceStream(STDERR, $loop);
+$in = new ReadableResourceStream(STDIN);
+$out = new WritableResourceStream(STDOUT);
+$info = new WritableResourceStream(STDERR);
 
 $decoder = new Decoder($in);
 $encoder = new Encoder($out);
@@ -30,6 +28,6 @@ $info->write('You can pipe/write a valid NDJson stream to STDIN' . PHP_EOL);
 $info->write('Valid NDJson will be forwarded to STDOUT' . PHP_EOL);
 $info->write('Invalid NDJson will raise an error on STDERR and exit with code 1' . PHP_EOL);
 
-$loop->run();
+Loop::run();
 
 exit($exit);


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

Builds on top of reactphp/event-loop#229, reactphp/event-loop#232 and reactphp/stream#159
Refs https://github.com/clue/reactphp-csv/pull/24