### PR TITLE
Check type of incoming `data` before trying to decode NDJSON

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -99,6 +99,11 @@ class Decoder extends EventEmitter implements ReadableStreamInterface
     /** @internal */
     public function handleData($data)
     {
+        if (!\is_string($data)) {
+            $this->handleError(new \UnexpectedValueException('Expected stream to emit string, but got ' . \gettype($data)));
+            return;
+        }
+
         $this->buffer .= $data;
 
         // keep parsing while a newline has been found

--- a/tests/DecoderTest.php
+++ b/tests/DecoderTest.php
@@ -67,6 +67,14 @@ class DecoderTest extends TestCase
         $this->input->emit('data', array("999888777666555444333222111000\n"));
     }
 
+    public function testEmitDataWithInvalidTypeWillForwardErrorWithUnexpectedValueException()
+    {
+        $this->decoder->on('data', $this->expectCallableNever());
+        $this->decoder->on('error', $this->expectCallableOnceWith($this->isInstanceOf('UnexpectedValueException')));
+
+        $this->input->emit('data', array(false));
+    }
+
     public function testEmitDataErrorWillForwardError()
     {
         $this->decoder->on('data', $this->expectCallableNever());


### PR DESCRIPTION
This changeset adds additional type checks for the incoming `data` before trying to decode as NDJSON. This should not affect normal usage, but helps with ensuring type safety and detecting issues when the `Decoder` has not been set up properly.

Builds on top of clue/reactphp-csv#27.