### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
     ignore `JSON_THROW_ON_ERROR` option (available as of PHP 7.3).
     (#14 by @clue)
 
-*   Feature: Add bechmarking script and import all global function references.
+*   Feature: Add benchmarking script and import all global function references.
     (#16 by @clue)
 
 *   Improve documentation and add NDJSON format description and
@@ -50,7 +50,7 @@
 *   Feature: Limit buffer size to 64 KiB by default.
     (#10 by @clue)
 
-*   Feature: Forward compatiblity with EventLoop v0.5 and upcoming v1.0.
+*   Feature: Forward compatibility with EventLoop v0.5 and upcoming v1.0.
     (#8 by @clue)
 
 *   Fix: Return bool `false` if encoding fails due to invalid value to pause source.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ it will emit an `error` event and then `close` the input stream:
 
 ```php
 $ndjson->on('error', function (Exception $error) {
-    // an error occured, stream will close next
+    // an error occurred, stream will close next
 });
 ```
 
@@ -270,7 +270,7 @@ it will emit an `error` event and then `close` the input stream:
 
 ```php
 $ndjson->on('error', function (Exception $error) {
-    // an error occured, stream will close next
+    // an error occurred, stream will close next
 });
 ```
 


### PR DESCRIPTION
This pull request fixes a few typos with the help of https://github.com/szepeviktor/typos-on-you.

Builds on top of #27 and #18.